### PR TITLE
feat(backend): use computation id

### DIFF
--- a/new/src/backend/app/api/v1/constants.py
+++ b/new/src/backend/app/api/v1/constants.py
@@ -1,0 +1,7 @@
+"""Api related constants."""
+
+# Maximum allowed sum of uploaded files.
+MAX_SETUP_FILES_SIZE = 1024 * 1024 * 250  # 250 MB
+
+# Allowed file types for computation
+ALLOWED_FILE_TYPES = ["cif", "mol2", "pdb", "mmcif", "sdf"]

--- a/new/src/backend/app/api/v1/middleware/exceptions.py
+++ b/new/src/backend/app/api/v1/middleware/exceptions.py
@@ -10,7 +10,5 @@ async def http_exception_handler(_: Request, exception: HTTPException):
     """Handle HTTP exceptions and return a JSON response with the error message."""
     return JSONResponse(
         status_code=exception.status_code,
-        content=ResponseError(
-            status_code=exception.status_code, message=exception.detail
-        ).model_dump_json(),
+        content=ResponseError(message=exception.detail).model_dump_json(),
     )

--- a/new/src/backend/app/api/v1/schemas/response.py
+++ b/new/src/backend/app/api/v1/schemas/response.py
@@ -7,7 +7,6 @@ class Response[T](BaseResponseSchema):
     """Response schema for a single item."""
 
     success: bool = True
-    status_code: int = 200
     data: T
 
 
@@ -16,4 +15,3 @@ class ResponseError(BaseResponseSchema):
 
     success: bool = False
     message: str
-    status_code: int = 400

--- a/new/src/backend/app/core/integrations/io/base.py
+++ b/new/src/backend/app/core/integrations/io/base.py
@@ -1,6 +1,10 @@
 """Base class for the file system interaction service."""
 
 from abc import ABC, abstractmethod
+import os
+import uuid
+
+from fastapi import UploadFile
 
 
 class IOBase(ABC):
@@ -36,3 +40,35 @@ class IOBase(ABC):
             bool: True if the operation was successful, otherwise False.
         """
         raise NotImplementedError()
+
+    @abstractmethod
+    def listdir(self, directory: str = ".") -> list[str]:
+        """Lists contents of the provided directory.
+
+        Args:
+            directory (str): Directory to list.
+
+        Returns:
+            str: List containing the names of the entries in the provided directory.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def store_upload_file(self, file: UploadFile, directory: str) -> tuple[str, str]:
+        """Stores the provided file on disk.
+
+        Args:
+            file (UploadFile): File to be stored.
+            directory (str): Path to an existing directory.
+
+        Returns:
+            tuple[str, str]: Tuple containing path to the file and hash of the file contents.
+        """
+        raise NotImplementedError()
+
+    @staticmethod
+    def get_unique_filename(filename: str) -> str:
+        """Generate unique filename."""
+
+        base, ext = os.path.splitext(filename)
+        return f"{str(uuid.uuid4())}_{base}{ext}"

--- a/new/src/backend/app/core/integrations/io/io.py
+++ b/new/src/backend/app/core/integrations/io/io.py
@@ -1,8 +1,11 @@
 """Module for IO operations."""
 
+import hashlib
 import os
 import shutil
-import uuid
+
+import aiofiles
+from fastapi import UploadFile
 
 from .base import IOBase
 
@@ -13,7 +16,7 @@ class IOLocal(IOBase):
     workdir: str = os.path.join("/", "tmp", "acc2")
 
     def create_tmp_dir(self, name: str = "") -> str:
-        path = os.path.join(IOLocal.workdir, name, str(uuid.uuid4()))
+        path = os.path.join(IOLocal.workdir, name)
         os.makedirs(path, exist_ok=True)
 
         return path
@@ -23,3 +26,18 @@ class IOLocal(IOBase):
 
     def cp(self, path_src: str, path_dst: str) -> str:
         return shutil.copy(path_src, path_dst)
+
+    def listdir(self, directory: str = ".") -> list[str]:
+        return os.listdir(directory)
+
+    async def store_upload_file(self, file: UploadFile, directory: str) -> tuple[str, str]:
+        path: str = os.path.join(directory, IOBase.get_unique_filename(file.filename))
+        hasher = hashlib.sha256()
+        chunk_size = 1024 * 1024  # 1 MB
+
+        async with aiofiles.open(path, "wb") as out_file:
+            while content := await file.read(chunk_size):
+                await out_file.write(content)
+                hasher.update(content)
+
+        return path, hasher.hexdigest()

--- a/new/src/backend/app/core/models/calculation.py
+++ b/new/src/backend/app/core/models/calculation.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass, field
 
-from pydantic import UUID4, BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 
 from core.integrations.chargefw2.base import Charges
@@ -44,7 +44,7 @@ class ChargeCalculationResult:
 class CalculationDto(BaseModel):
     """Calculation data transfer object"""
 
-    id: UUID4
+    file: str
     method: str
     parameters: str | None
     read_hetatm: bool
@@ -61,7 +61,7 @@ class CalculationDto(BaseModel):
         """Create DTO from calculation result"""
 
         return CalculationDto(
-            id=result.id,
+            file=result.file,
             method=config.method,
             parameters=config.parameters,
             read_hetatm=config.read_hetatm,

--- a/new/src/backend/app/core/models/calculation.py
+++ b/new/src/backend/app/core/models/calculation.py
@@ -25,7 +25,7 @@ class CalculationsFilters:
 class ChargeCalculationConfig:
     """Configuration for charge calculation"""
 
-    method: str
+    method: str | None
     parameters: str | None
     read_hetatm: bool = True
     ignore_water: bool = False

--- a/new/src/backend/app/core/models/calculation.py
+++ b/new/src/backend/app/core/models/calculation.py
@@ -32,8 +32,8 @@ class ChargeCalculationConfig:
 
 
 @dataclass
-class ChargeCalculationResult:
-    """Result of charge calculation"""
+class ChargeCalculationPart:
+    """Result of charge calculation for a single file."""
 
     file: str
     file_hash: str
@@ -45,27 +45,25 @@ class CalculationDto(BaseModel):
     """Calculation data transfer object"""
 
     file: str
-    method: str
-    parameters: str | None
-    read_hetatm: bool
-    ignore_water: bool
     charges: dict
     success: bool = True
 
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True, from_attributes=True)
 
     @staticmethod
-    def from_result(
-        result: ChargeCalculationResult, config: ChargeCalculationConfig
-    ) -> "CalculationDto":
+    def from_result(result: ChargeCalculationPart) -> "CalculationDto":
         """Create DTO from calculation result"""
 
         return CalculationDto(
             file=result.file,
-            method=config.method,
-            parameters=config.parameters,
-            read_hetatm=config.read_hetatm,
-            ignore_water=config.ignore_water,
             charges=result.charges,
             success=result.charges is not None,
         )
+
+
+@dataclass
+class ChargeCalculationResult:
+    """Result of charge calculation"""
+
+    config: ChargeCalculationConfig
+    calculations: list[CalculationDto]

--- a/new/src/backend/app/core/models/molecule_info.py
+++ b/new/src/backend/app/core/models/molecule_info.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class AtomTypeCount:
+    """Counts of atom types."""
+
+    symbol: str
+    count: int
+
+    def __init__(self, type_counts: dict[str, Any]) -> None:
+        self.symbol = type_counts.get("symbol", "") or ""
+        self.count = type_counts.get("count", 0)
+
+
+@dataclass
+class MoleculeInfo:
+    """Information about the molecules in the provided file."""
+
+    total_molecules: int
+    total_atoms: int
+    atom_type_counts: list[AtomTypeCount]
+
+    def __init__(self, info: dict[str, Any]) -> None:
+        self.total_molecules = info.get("total_molecules", 0)
+        self.total_atoms = info.get("total_atoms", 0)
+        self.atom_type_counts = [AtomTypeCount(x) for x in info.get("atom_type_counts", [])]

--- a/new/src/backend/app/core/models/setup.py
+++ b/new/src/backend/app/core/models/setup.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Setup:
+    """Setup model."""
+
+    computation_id: str

--- a/new/src/backend/app/core/models/suitable_methods.py
+++ b/new/src/backend/app/core/models/suitable_methods.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class SuitableMethods:
+    """Result of suitable methods calculation."""
+
+    methods: list[str]
+    parameters: dict[str, list[str]]

--- a/new/src/backend/app/db/repositories/calculations_repository.py
+++ b/new/src/backend/app/db/repositories/calculations_repository.py
@@ -10,7 +10,7 @@ from core.models.calculation import (
     ChargeCalculationConfig,
     CalculationDto,
     CalculationsFilters,
-    ChargeCalculationResult,
+    ChargeCalculationPart,
 )
 
 from db.models.calculation import Calculation
@@ -56,7 +56,7 @@ class CalculationsRepository:
             return CalculationDto.model_validate(calculation) if calculation else None
 
     def store(
-        self, calculation_result: ChargeCalculationResult, config: ChargeCalculationConfig
+        self, calculation_result: ChargeCalculationPart, config: ChargeCalculationConfig
     ) -> CalculationDto:
         """Store a single calculation result in the database."""
 
@@ -77,7 +77,7 @@ class CalculationsRepository:
             return CalculationDto.model_validate(calculation)
 
     def store_multiple(
-        self, calculation_results: list[ChargeCalculationResult], config: ChargeCalculationConfig
+        self, calculation_results: list[ChargeCalculationPart], config: ChargeCalculationConfig
     ) -> None:
         """Store multiple calculation results in the database."""
 

--- a/new/src/backend/app/services/io.py
+++ b/new/src/backend/app/services/io.py
@@ -1,9 +1,7 @@
 """Service for handling file operations."""
 
-import aiofiles
-import hashlib
 import os
-import uuid
+
 
 from fastapi import UploadFile
 
@@ -26,54 +24,47 @@ class IOService:
         if name == "":
             raise ValueError("Name cannot be empty.")
 
-        self.logger.info(f"Creating temporary directory with name: {name}")
-
-        path = self.io.create_tmp_dir(name)
-
-        self.logger.info(f"Created temporary directory: {path}")
-
-        return path
+        try:
+            self.logger.info(f"Creating temporary directory with name: {name}")
+            path = self.io.create_tmp_dir(name)
+            return path
+        except Exception as e:
+            self.logger.info(f"Unable to create temporary directory '{name}': {e}")
+            raise e
 
     def remove_tmp_dir(self, path: str) -> None:
         """Remove temporary directory."""
 
-        self.logger.info(f"Clearing temporary directory {path}")
-        self.io.remove_tmp_dir(path)
+        self.logger.info(f"Removing temporary directory {path}")
+
+        try:
+            self.io.remove_tmp_dir(path)
+        except Exception as e:
+            self.logger.error(f"Unable to remove temporary directory '{path}': {e}")
+            raise e
 
     def cp(self, path_from: str, path_to: str) -> str:
         """Copy file from source to destination."""
 
         self.logger.info(f"Copying from {path_from} to {path_to}.")
 
-        path = self.io.cp(path_from, path_to)
+        try:
+            path = self.io.cp(path_from, path_to)
+            return path
+        except Exception as e:
+            self.logger.error(f"Unable to copy '{path_from}' to '{path_to}': {e}")
+            raise e
 
-        self.logger.info(f"Successfully copied from {path_from} to {path_to}.")
-
-        return path
-
-    async def store_upload_file(self, file: UploadFile, dir_name: str) -> tuple[str, str]:
+    async def store_upload_file(self, file: UploadFile, directory: str) -> tuple[str, str]:
         """Store uploaded file in the provided directory."""
-
-        os.makedirs(dir_name, exist_ok=True)
-        path: str = os.path.join(dir_name, IOService.get_unique_filename(file.filename))
-        hasher = hashlib.sha256()
-        chunk_size = 64 * 1024  # 64 KB
+        self.logger.info(f"Storing file {file.filename}.")
 
         try:
-            self.logger.info(f"Storing file {file.filename}.")
-            async with aiofiles.open(path, "wb") as out_file:
-                while content := await file.read(chunk_size):
-                    await out_file.write(content)
-                    hasher.update(content)
-
-            return path, hasher.hexdigest()
+            return await self.io.store_upload_file(file, directory)
         except Exception as e:
             self.logger.error(f"Error storing file {file.filename}: {e}")
             raise e
 
-    @staticmethod
-    def get_unique_filename(filename: str) -> str:
-        """Generate unique filename."""
-
-        base, ext = os.path.splitext(filename)
-        return f"{str(uuid.uuid4())}_{base}{ext}"
+    async def listdir(self, directory: str) -> list[str]:
+        """List directory contents."""
+        return self.io.listdir(directory)

--- a/new/src/backend/poetry.lock
+++ b/new/src/backend/poetry.lock
@@ -266,6 +266,43 @@ uvicorn = {version = ">=0.15.0", extras = ["standard"]}
 standard = ["uvicorn[standard] (>=0.15.0)"]
 
 [[package]]
+name = "gemmi"
+version = "0.7.0"
+description = "library for structural biology"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "gemmi-0.7.0-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:d5c26bf3a1cef9f6cc250dc5426cff5e44397186729a07ebb20fa9825198af95"},
+    {file = "gemmi-0.7.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:35abeee20456d5c0e9de0e91c5ea4c1b86d03db6f6feb25bc4ef45e44fded39f"},
+    {file = "gemmi-0.7.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2300eea898e5bda394c3721ce3873209303bd0402d83e4324d7f431b15f3bfe7"},
+    {file = "gemmi-0.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:591ad3baba259a1d7398dc40d4691b51b4e79ffed3f29e19d012e117bfbb1992"},
+    {file = "gemmi-0.7.0-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:c830ed429ef208870e02f8c43ffc6e9b8abf1ecc5240208ff183270a8ee70c87"},
+    {file = "gemmi-0.7.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7c3c6ea7f5388e2e72cd5f6f98eeee6cf417cbd4bf86ba64cb89e96b52341b06"},
+    {file = "gemmi-0.7.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49ee5c7a457b5dda1f1bff76b0b0dfdb2ef7499483a517e77ad5bb1628d5daa9"},
+    {file = "gemmi-0.7.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bfe1ba4c28c917dfc695db680a0d0ea314741dd3b86b574a219896ae41c50683"},
+    {file = "gemmi-0.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:7f08814ccd49e9cb4e5a6f134f64a83cd9ebcde2dfc7d1fda8c88610336f6263"},
+    {file = "gemmi-0.7.0-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:de55132d9d1c235f44e5ac220816b37b00db4e68bd1fb9641171cc90c5584a4a"},
+    {file = "gemmi-0.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:26967752d52060a822c0ae9e4bd17839f65712f8dafd68fd0953976b7366e143"},
+    {file = "gemmi-0.7.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae8163b58a2523b3d3415993ce5180f67b3b6bbf2a355d9122e4826b24215448"},
+    {file = "gemmi-0.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:51d67b793fe755788cfea6e24427f250950d7a8d3c3e28c53255efeaa238cb1d"},
+    {file = "gemmi-0.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:1b0a28f8fc03b5777e53f4368ddf53d99d35f96ac2476d95c14f96e468903de2"},
+    {file = "gemmi-0.7.0-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:2cf89eca009b3d91ab5b864790989e5b372718b437a4ab6e1356d712280f156c"},
+    {file = "gemmi-0.7.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7241fb1560b637d78ab0cc60f7d4ad370d97a990663bf485b729de3d1361ded1"},
+    {file = "gemmi-0.7.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4074576d236c86c26da2d4e267bd7a8ad74bf9e0988d9dbc65146b20623de810"},
+    {file = "gemmi-0.7.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bb311ba9b9085eb8ccd666d574a0b511b6bc5161d0f72459f8f95652234100ad"},
+    {file = "gemmi-0.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bb168e79709ac4733b2a02ce1395e4621d128a13f9da06f9157e13ede6af825"},
+    {file = "gemmi-0.7.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:86fe913d0f64bafd0d83c026a3a19767052568b1411c4d68633e4ff240b3222d"},
+    {file = "gemmi-0.7.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:eb97903ba7009a4db555c13d2613bc181101d233c040077ee8c1b58a208cf28a"},
+    {file = "gemmi-0.7.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d04d6b72e8eb65a21937b6b20f725bb5202cb9802ac93af853fb240f4535c5f"},
+    {file = "gemmi-0.7.0-cp38-cp38-win_amd64.whl", hash = "sha256:70cbbd521103214e09d63b3421a6cd2c538c102a8f51eb254cbe09693e6804d0"},
+    {file = "gemmi-0.7.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:f066058db50e016b0e0d9f38cf50391065792a3d70e790bcb4c942de0892471c"},
+    {file = "gemmi-0.7.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:48e9fbf91b6b6e21a474abec1e70370eff59c343b888f244ee9f57393fbe54da"},
+    {file = "gemmi-0.7.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:375937479efefa738dd34613e8342c784580f7699cf03e2bb967100b1b97a9ea"},
+    {file = "gemmi-0.7.0-cp39-cp39-win_amd64.whl", hash = "sha256:900b86286bdbd4aa8f393b372e3c984ab62cd67b5bb7b77de2bc24073aa768cb"},
+    {file = "gemmi-0.7.0.tar.gz", hash = "sha256:758604664b20d0ea59e81ff757fd40572f69918e65ac2e6c690709fbd9ebc0c5"},
+]
+
+[[package]]
 name = "greenlet"
 version = "3.1.1"
 description = "Lightweight in-process concurrent programming"
@@ -1370,4 +1407,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "1365ee7f6838b9210d190519f992da39526414484e1afd80d851fdfc8d6d173c"
+content-hash = "a590bb46a1320bb661303e06796617b2e0a01179f51fdc58d1f54fb3927804eb"

--- a/new/src/backend/pyproject.toml
+++ b/new/src/backend/pyproject.toml
@@ -20,6 +20,7 @@ uvicorn-worker = "^0.2.0"
 gunicorn = "^23.0.0"
 sqlalchemy = "^2.0.37"
 psycopg2 = "^2.9.10"
+gemmi = "^0.7.0"
 
 
 [build-system]


### PR DESCRIPTION
- Upload files before computation and return `computation_id`, which can later be used to refer to these files.
- Add response models
- Add file hash to its name
- wip: mmcif response