### PR TITLE
fix(backend): cache for suitable, semaphore limit

### DIFF
--- a/new/src/backend/app/api/v1/routes/charges.py
+++ b/new/src/backend/app/api/v1/routes/charges.py
@@ -236,11 +236,6 @@ async def calculate_charges(
                 + f"Maximum storage space is {quota_mb} MB.",
             )
 
-    configs = data.configs
-    if not configs:
-        # cache (db) is not being used when no config is provided
-        configs = [CalculationConfigDto()]
-
     computation_id = data.computation_id or str(uuid.uuid4())
     calculation_set = storage_service.get_calculation_set(computation_id)
 
@@ -272,6 +267,21 @@ async def calculate_charges(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="No file hashes provided.",
             )
+
+        configs = data.configs
+        if not configs:
+            # use most suitable method and parameters if none provided
+            suitable = await chargefw2.get_computation_suitable_methods(computation_id, user_id)
+
+            if len(suitable.methods) == 0:
+                # TODO: show message?
+                raise Exception("No suitable methods found.")
+
+            method_name = suitable.methods[0].internal_name
+            parameters = suitable.parameters.get(method_name, [])
+            parameters_name = parameters[0].internal_name if len(parameters) > 0 else None
+
+            configs = [CalculationConfigDto(method=method_name, parameters=parameters_name)]
 
         # split calculations into those that need to be calculated and those that are cached
         to_calculate, cached = storage_service.filter_existing_calculations(

--- a/new/src/backend/app/api/v1/routes/charges.py
+++ b/new/src/backend/app/api/v1/routes/charges.py
@@ -350,7 +350,7 @@ async def setup(
 
 
 # chemical/x-cif
-@charges_router.get("/{computation_id}/mmcif")
+@charges_router.get("/{computation_id}/mmcif", include_in_schema=False)
 @inject
 async def get_mmcif(
     request: Request,
@@ -482,7 +482,7 @@ async def get_calculations(
         ) from e
 
 
-@charges_router.delete("/{computation_id}")
+@charges_router.delete("/{computation_id}", include_in_schema=False)
 @inject
 async def delete_calculation(
     request: Request,

--- a/new/src/backend/app/api/v1/schemas/charges.py
+++ b/new/src/backend/app/api/v1/schemas/charges.py
@@ -1,5 +1,6 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
+from pydantic.json_schema import SkipJsonSchema
 
 from models.calculation import CalculationConfigDto
 from models.setup import AdvancedSettingsDto
@@ -28,7 +29,9 @@ class CalculateChargesRequest(BaseRequestModel):
     configs: list[CalculationConfigDto]
     file_hashes: list[str]
     settings: AdvancedSettingsDto | None = None
-    computation_id: str | None = None
+
+    # exclude computation_id from docs
+    computation_id: SkipJsonSchema[str | None] = Field(None, exclude=True)
 
 
 class SetupRequest(BaseRequestModel):

--- a/new/src/backend/entrypoint.sh
+++ b/new/src/backend/entrypoint.sh
@@ -5,6 +5,11 @@
 
 cd /acc2/app
 
+# run database migrations
 alembic upgrade head
 
-exec gunicorn --workers 4 --worker-class uvicorn.workers.UvicornWorker --timeout 600 --bind 0.0.0.0:8000 main:web_app
+# use gunicorn with 4 workers
+# uvicorn.workers.UvicornWorker is used for async processing
+# setting timeout to 1 hour for long lasting computations
+# running on port 8000
+exec gunicorn --workers 4 --worker-class uvicorn.workers.UvicornWorker --timeout 6000 --bind 0.0.0.0:8000 main:web_app


### PR DESCRIPTION
- Fixed cache not being used when calculating with the default method and params
- Fixed semaphore so that the calculations are actually being limited
- Excluded get mmcif and delete calculation from docs
- Excluded `computation_id` from `/calculate` docs 