### PR TITLE
misc: use master instead of arch-redesign in ci

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -3,11 +3,11 @@ name: Backend CI
 on:
   push:
     branches:
-      - architecture-redesign # TODO: change to main when merged to upstream
+      - master
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
-      - architecture-redesign # TODO: change to main when merged to upstream
+      - master
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -3,11 +3,11 @@ name: Frontend CI
 on:
   push:
     branches:
-      - architecture-redesign # TODO: change to main when merged to upstream
+      - master
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
-      - architecture-redesign # TODO: change to main when merged to upstream
+      - master
   workflow_dispatch:
 
 jobs:

--- a/src/backend/app/services/logging/file_logger.py
+++ b/src/backend/app/services/logging/file_logger.py
@@ -25,7 +25,7 @@ class FileLogger(LoggerBase):
             filename=os.path.join(self.logdir, self.file_name),
             level=logging.INFO,
             filemode="a+",
-            format="%(asctime)s [%(levelname)s] %(message)s",  # TODO: what format should be used?
+            format="%(asctime)s [%(levelname)s] %(message)s",
         )
 
         self.logger = logging.getLogger(__name__)


### PR DESCRIPTION
- Using master branch instead of architecture-redesign so that it runs on upstream